### PR TITLE
Only call Bitbuckets annotations API when there are code smells 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitbucket-report-sonarqube",
   "bin": "src/index.js",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Commandline tool to use the management APIs of SAP API Management",
   "main": "src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -112,13 +112,15 @@ program.name(name)
         }
       })
 
-      await axios.post(`https://api.bitbucket.org/2.0/repositories/${program.reposlug}/commit/${program.commit}/reports/${program.reportId}/annotations`,
-        issues, {
-          proxy: {
-            host: 'localhost',
-            port: 29418
-          }
-        })
+      if (issues.length > 0) {
+        await axios.post(`https://api.bitbucket.org/2.0/repositories/${program.reposlug}/commit/${program.commit}/reports/${program.reportId}/annotations`,
+            issues, {
+              proxy: {
+                host: 'localhost',
+                port: 29418
+              }
+            })
+      }
     } catch (e) {
       e.response ? console.log(e.response.data) : console.log(e.message)
       process.exit(1)


### PR DESCRIPTION
When Bitbuckets annotations API get's called with an empty Array it returns the following error:
```json
{ "code": 400, "message": "annotation batch is empty" }
```

I've added a simple if-statement to check if the issues Array has more than 0 items.